### PR TITLE
吹き出しコンポーネントの実装

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { Box } from "@mui/material";
-import SpeechBubble from "@/features/base/components/SpeechBubble";
 
 export default function Home() {
   return <Box>Chat</Box>;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Box } from "@mui/material";
+import SpeechBubble from "@/features/base/components/SpeechBubble";
 
 export default function Home() {
   return <Box>Chat</Box>;

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -2,7 +2,16 @@
 
 import React from "react";
 import { Box } from "@mui/material";
+import SpeechBubble from "@/features/base/components/SpeechBubble";
 
 export default function Home() {
-  return <Box>Test</Box>;
+  return (
+    <Box>
+      <SpeechBubble
+        content="モナリザって誰が書いたのOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO？"
+        sender={false}
+      />
+      <SpeechBubble content="レオナルドダヴィンチだよ！" sender={true} />
+    </Box>
+  );
 }

--- a/src/features/base/components/SpeechBubble.tsx
+++ b/src/features/base/components/SpeechBubble.tsx
@@ -5,8 +5,8 @@ import { Box, Typography } from "@mui/material";
 
 interface SpeechBubbleProps {
   content: string;
-  sender?: boolean; // If true, the message is from the sender
-  bubbleColor?: string; // Custom bubble color
+  sender?: boolean;
+  bubbleColor?: string;
 }
 
 const SpeechBubble: React.FC<SpeechBubbleProps> = ({
@@ -28,10 +28,9 @@ const SpeechBubble: React.FC<SpeechBubbleProps> = ({
           color: sender ? "common.white" : "common.black",
           maxWidth: "60%",
           padding: "8px 12px",
-          borderRadius: sender ? "16px 16px 4px 16px" : "16px 16px 16px 4px", // Adjusts border radius for tail
+          borderRadius: sender ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
           boxShadow: "2px 2px 6px rgba(0, 0, 0, 0.2)",
           position: "relative",
-          fontFamily: "SF Pro Text",
           wordWrap: "break-word",
         }}
       >

--- a/src/features/base/components/SpeechBubble.tsx
+++ b/src/features/base/components/SpeechBubble.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+interface SpeechBubbleProps {
+  content: string;
+  sender?: boolean; // If true, the message is from the sender
+  bubbleColor?: string; // Custom bubble color
+}
+
+const SpeechBubble: React.FC<SpeechBubbleProps> = ({
+  content,
+  sender = true,
+  bubbleColor = sender ? "accent.main" : "background.paper",
+}) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: sender ? "flex-end" : "flex-start",
+        marginY: "8px",
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: bubbleColor,
+          color: sender ? "common.white" : "common.black",
+          maxWidth: "60%",
+          padding: "8px 12px",
+          borderRadius: sender ? "16px 16px 4px 16px" : "16px 16px 16px 4px", // Adjusts border radius for tail
+          boxShadow: "2px 2px 6px rgba(0, 0, 0, 0.2)",
+          position: "relative",
+          fontFamily: "SF Pro Text",
+          wordWrap: "break-word",
+        }}
+      >
+        <Typography variant="body1">{content}</Typography>
+
+        {/* Tail */}
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: 0,
+            width: 0,
+            height: 0,
+            border: "8px solid transparent",
+            borderTopColor: bubbleColor,
+            left: sender ? "auto" : "-8px",
+            right: sender ? "-8px" : "auto",
+          }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default SpeechBubble;


### PR DESCRIPTION

![Screenshot 2024-12-18 143517](https://github.com/user-attachments/assets/b1b2cc6f-adcf-4eed-a1e3-87da43997125)


SpeechBubbleコンポーネントを作成した。
Propsとして、内容のcontent、senderであるかのboolとbubbleColorがある。

使い方は以下のよう：
<SpeechBubble
        content="内容？"
        sender={falseもしくはtrue}
      />

四角（ユーザなら白、Artieなら赤、内容の長さによって大きさが変化すす）、三角（ユーザなら右下、Artieなら左下)