### PR TITLE
gcpをpersonal access tokenではなく、サービスアカウントから動的にアクセストークンを発行させるように変えた。

### DIFF
--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -1,6 +1,6 @@
+import { getAccessToken } from "@/lib/getAccessToken";
 import { NextResponse } from "next/server";
 
-const GOOGLE_CLOUD_ACCESS_TOKEN = process.env.GOOGLE_CLOUD_ACCESS_TOKEN;
 const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT_ID;
 const LOCATION = process.env.GOOGLE_CLOUD_LOCATION || "us-central1";
 const ENDPOINT_ID = process.env.GOOGLE_CLOUD_MODEL_ID;
@@ -19,10 +19,12 @@ export async function POST(req: Request) {
       );
     }
 
+    const accessToken = await getAccessToken();
+
     const response = await fetch(ENDPOINT, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${GOOGLE_CLOUD_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -57,7 +59,6 @@ export async function POST(req: Request) {
 
     const maxConfidence = predictions.confidences[maxConfidenceIndex];
     const maxId = predictions.ids[maxConfidenceIndex];
-    console.log(predictions);
 
     if (maxConfidence < 0.8) {
       return NextResponse.json(

--- a/src/lib/getAccessToken.ts
+++ b/src/lib/getAccessToken.ts
@@ -1,0 +1,14 @@
+import { GoogleAuth } from "google-auth-library";
+
+export const getAccessToken = async () => {
+  const auth = new GoogleAuth({
+    credentials: JSON.parse(
+      process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON || "{}",
+    ),
+    scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+  });
+
+  const client = await auth.getClient();
+  const accessToken = await client.getAccessToken();
+  return accessToken.token;
+};


### PR DESCRIPTION
そういえば、デプロイ環境ではpersonal access tokenのハードコードだと弾かれるので、動的に生成させるようにした。(セキュリティ的にはあまり良くない。)